### PR TITLE
fix: kintone ES6 settings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,19 +3,10 @@ module.exports = {
   // 呼び出したいルール（パッケージ）
   // --------------------------------
   // ES5 & kintone の場合
-  extends: "@cybozu/eslint-config/presets/kintone-customize-es5",
+  // extends: ["./es5.js"],
 
   // ES6以上 & kintone の場合
-  // extends: [
-  //   '@cybozu',
-  //   '@cybozu/eslint-config/globals/kintone',
-  // ],
-  // parserOptions: {
-  //   sourceType: 'script',
-  // },
-  // rules: {
-  //   strict: ['error', 'function'],
-  // },
+  // extends: ["./es6.js"],
 
   // node & kintone の場合
   // extends: ["@cybozu/eslint-config/presets/node", "@cybozu/eslint-config/globals/kintone"],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,16 @@ module.exports = {
   extends: "@cybozu/eslint-config/presets/kintone-customize-es5",
 
   // ES6以上 & kintone の場合
-  // extends: ["@cybozu", "@cybozu/eslint-config/globals/kintone"],
+  // extends: [
+  //   '@cybozu',
+  //   '@cybozu/eslint-config/globals/kintone',
+  // ],
+  // parserOptions: {
+  //   sourceType: 'script',
+  // },
+  // rules: {
+  //   strict: ['error', 'function'],
+  // },
 
   // node & kintone の場合
   // extends: ["@cybozu/eslint-config/presets/node", "@cybozu/eslint-config/globals/kintone"],

--- a/es5.js
+++ b/es5.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: "@cybozu/eslint-config/presets/kintone-customize-es5"
+};

--- a/es6.js
+++ b/es6.js
@@ -1,0 +1,12 @@
+module.exports = {
+  extends: [
+    '@cybozu',
+    '@cybozu/eslint-config/globals/kintone',
+  ],
+  parserOptions: {
+    sourceType: 'script',
+  },
+  rules: {
+    strict: ['error', 'function'],
+  },
+};


### PR DESCRIPTION
kintone で ES6+ の設定を使うとき、use strict が強制されない

これは、`"sourceType": "module"` になっているためである。
https://eslint.org/docs/rules/strict#rule-details

strict を強制するには、`cybozu/eslint-config` の es5 preset で行っているように、`"sourceType": "script"` にする
https://github.com/cybozu/eslint-config/blob/master/lib/es5.js#L11

また、設定が長くなってしまうので、設定を別のファイルにして import するようにする