### PR TITLE
disable arrow function

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,10 @@ module.exports = {
 
   // ES6以上 & kintone の場合
   // extends: ["./es6.js"],
+  // アロー関数を許可しない場合は、以下のコメントを外す
+  // rules: {
+  //   'prefer-arrow-callback': ['off']
+  // },
 
   // node & kintone の場合
   // extends: ["@cybozu/eslint-config/presets/node", "@cybozu/eslint-config/globals/kintone"],


### PR DESCRIPTION
ES2015+ のときにアロー関数を使いたくない場合のルールを追加